### PR TITLE
Add connect commands for Bluetooth audio devices. 

### DIFF
--- a/src/Commands/ConnectBluetoothAudioDeviceByMac.cs
+++ b/src/Commands/ConnectBluetoothAudioDeviceByMac.cs
@@ -1,0 +1,21 @@
+using BluetoothDevicePairing.Bluetooth.Devices;
+using BluetoothDevicePairing.Commands.Utils;
+using CommandLine;
+
+namespace BluetoothDevicePairing.Commands;
+
+[Verb("connect-bluetooth-audio-device-by-mac",
+      HelpText = "Connect a Bluetooth audio device using its mac address")]
+internal sealed class ConnectBluetoothAudioDeviceByMacOptions : MacAndDeviceTypeOptions
+{
+}
+
+internal static class ConnectBluetoothAudioDeviceByMac
+{
+    public static void Execute(ConnectBluetoothAudioDeviceByMacOptions opts)
+    {
+        var mac = new DeviceMacAddress(opts.Mac);
+        var device = DeviceFinder.FindDevicesByMac(mac, opts.DeviceType);
+        AudioDeviceConnector.ConnectBluetoothAudioDevice(device);
+    }
+}

--- a/src/Commands/ConnectBluetoothAudioDeviceByName.cs
+++ b/src/Commands/ConnectBluetoothAudioDeviceByName.cs
@@ -1,0 +1,28 @@
+using BluetoothDevicePairing.Bluetooth.Devices;
+using BluetoothDevicePairing.Commands.Utils;
+using BluetoothDevicePairing.Utils;
+using CommandLine;
+
+namespace BluetoothDevicePairing.Commands;
+
+[Verb("connect-bluetooth-audio-device-by-name",
+      HelpText = "Connect a Bluetooth audio device using its name")]
+internal sealed class ConnectBluetoothAudioDeviceByNameOptions : PairAndUnpairDeviceByNameOptions
+{
+}
+
+internal static class ConnectBluetoothAudioDeviceByName
+{
+    public static void Execute(ConnectBluetoothAudioDeviceByNameOptions opts)
+    {
+        var devices = DeviceFinder.FindDevicesByName(DeviceDiscoverer.DiscoverPairedBluetoothDevices(new DiscoveryTime(opts.DiscoveryTime)),
+                                                     opts.DeviceName,
+                                                     opts.DeviceType);
+        if (devices.Count > 1)
+        {
+            throw new AppException($"{devices.Count} devices found, don't know which one to choose");
+        }
+
+        AudioDeviceConnector.ConnectBluetoothAudioDevice(devices[0]);
+    }
+}

--- a/src/Commands/Utils/AudioDeviceConnector.cs
+++ b/src/Commands/Utils/AudioDeviceConnector.cs
@@ -1,0 +1,36 @@
+using BluetoothDevicePairing.Bluetooth.Devices;
+using System.Linq;
+using System;
+using BluetoothDevicePairing.Utils;
+
+namespace BluetoothDevicePairing.Commands.Utils;
+
+internal static class AudioDeviceConnector
+{
+    public static void ConnectBluetoothAudioDevice(Device device)
+    {
+        Console.WriteLine($"Request to connect Bluetooth audio devices associated with [{device}]");
+
+        if (device.ConnectionStatus == ConnectionStatus.NotPaired)
+        {
+            throw new AppException($"The device '{device.Name}' is not paired");
+        }
+
+        if (device.ConnectionStatus == ConnectionStatus.Connected)
+        {
+            throw new AppException($"The device '{device.Name}' is already connected");
+        }
+
+        if (!device.AssociatedAudioDevices.Any())
+        {
+            throw new AppException($"The device '{device.Name}' is not an audio device");
+        }
+
+        Console.WriteLine($"Connecting audio devices associated with '{device.Name}'");
+
+        foreach (var audioDevice in device.AssociatedAudioDevices)
+        {
+            audioDevice.Connect();
+        }
+    }
+}

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -10,6 +10,8 @@ static void ParseCommandLineAndExecuteActions(string[] args)
                                       PairDeviceByNameOptions,
                                       UnpairDeviceByMacOptions,
                                       UnpairDeviceByNameOptions,
+                                      ConnectBluetoothAudioDeviceByNameOptions,
+                                      ConnectBluetoothAudioDeviceByMacOptions,
                                       DisconnectBluetoothAudioDeviceByNameOptions,
                                       DisconnectBluetoothAudioDeviceByMacOptions,
                                       ListAdaptersOptions>(args)
@@ -18,6 +20,8 @@ static void ParseCommandLineAndExecuteActions(string[] args)
           .WithParsed<PairDeviceByNameOptions>(PairDeviceByName.Execute)
           .WithParsed<UnpairDeviceByMacOptions>(UnPairDeviceByMac.Execute)
           .WithParsed<UnpairDeviceByNameOptions>(UnPairDeviceByName.Execute)
+          .WithParsed<ConnectBluetoothAudioDeviceByNameOptions>(ConnectBluetoothAudioDeviceByName.Execute)
+          .WithParsed<ConnectBluetoothAudioDeviceByMacOptions>(ConnectBluetoothAudioDeviceByMac.Execute)
           .WithParsed<DisconnectBluetoothAudioDeviceByNameOptions>(DisconnectBluetoothAudioDeviceByName.Execute)
           .WithParsed<DisconnectBluetoothAudioDeviceByMacOptions>(DisconnectBluetoothAudioDeviceByMac.Execute)
           .WithParsed<ListAdaptersOptions>(ListAdapters.Execute);


### PR DESCRIPTION
- Add `connect-bluetooth-audio-device-by-mac` command to connect a Bluetooth audio device using its MAC address
- Add `connect-bluetooth-audio-device-by-name` command to connect a Bluetooth audio device using its name
- Add `AudioDeviceConnector` utility class mirroring the existing `AudioDeviceDisconnector`

The `AudioDevice` class already had a `Connect()` method using `KSPROPERTY_ONESHOT_RECONNECT`, but it wasn't exposed via CLI commands. This adds the missing command-line interface to complement the existing disconnect commands.